### PR TITLE
Remove futures from requirement.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM python:2.7
 
 RUN apt-get update && apt-get install libgtk2.0 -y
 RUN pip install opencv-python
-RUN pip install futures
+RUN pip install opencv-python futures
 
 COPY . /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,6 @@
 FROM python:2.7
 
 RUN apt-get update && apt-get install libgtk2.0 -y
-RUN pip install opencv-python
 RUN pip install opencv-python futures
 
 COPY . /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ FROM python:2.7
 
 RUN apt-get update && apt-get install libgtk2.0 -y
 RUN pip install opencv-python
+RUN pip install futures
 
 COPY . /app
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ requests
 opencv-python
 flake8
 opencv-contrib-python
-futures


### PR DESCRIPTION
futures is a standard library in python 3, this import instead installs a python 2 back port of the feature. When the futures library is installed in a python 3 env it breaks most apps (somehow not this one).